### PR TITLE
Add IP address display module

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,6 +5,7 @@ MODULES_AVAILABLE := gfx_random_static gfx_random_rects gfx_twinkle gfx_gol
 MODULES_AVAILABLE += gfx_rainbow gfx_math_sinpi gfx_text gfx_plasma gfx_checkerboard
 MODULES_AVAILABLE += gfx_balls gfx_clock gfx_sinematrix gfx_error gfx_partirush
 MODULES_AVAILABLE += gfx_matrix gfx_cube gfx_mandelbrot gfx_golc gfx_sinefield gfx_affinematrix
+MODULES_AVAILABLE += gfx_ip
 
 MODULES_AVAILABLE += out_dummy out_sdl2 out_rpi_ws2812b out_udp out_fb out_rpi_hub75
 MODULES_AVAILABLE += out_sf75_bi_spidev
@@ -15,6 +16,7 @@ MODULES := gfx_random_static gfx_random_rects gfx_twinkle gfx_gol
 MODULES += gfx_rainbow gfx_math_sinpi gfx_plasma gfx_checkerboard
 MODULES += gfx_balls gfx_clock gfx_sinematrix gfx_error gfx_partirush
 MODULES += gfx_matrix gfx_cube gfx_mandelbrot gfx_golc gfx_sinefield gfx_affinematrix
+MODULES += gfx_ip
 
 MODULES += bgm_fish bgm_opc bgm_pixelflut
 MODULES += flt_gamma_correct flt_flip_x flt_flip_y flt_scale

--- a/src/modules/Makefile
+++ b/src/modules/Makefile
@@ -29,6 +29,7 @@ flt_gamma_correct.so: LIBS += -lm
 gfx_text.so: text.o
 gfx_clock.so: text.o
 gfx_error.so: text.o
+gfx_ip.so: text.o
 gfx_sinematrix.so: LIBS += -lm
 gfx_affinematrix.so: LIBS += -lm
 gfx_sinefield.so: LIBS += -lm

--- a/src/modules/gfx_ip.c
+++ b/src/modules/gfx_ip.c
@@ -1,0 +1,76 @@
+#include <types.h>
+#include <matrix.h>
+#include <timers.h>
+#include <string.h>
+
+#include <sys/types.h>
+#include <ifaddrs.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#include "text.h"
+
+#define FRAMETIME (T_SECOND)
+#define FRAMES (RANDOM_TIME)
+#define CHARS_FULL 8 // 20:15:09, must also hold 20:15 (small)
+
+static text* rendered = NULL;
+
+int init(int modno, char *argstr) {
+	// max digit size is 4, plus 3 for ., (4 * 3) * 4 + 3 * 3 = 57
+	//TODO split ip into multiple rows
+	if (matrix_getx() < 57)
+		return 1; // not enough X to be usable
+	if (matrix_gety() < 7)
+		return 1; // not enough Y to be usable
+
+	//TODO allow to customize these, can we use argstr here?
+	int target_family = AF_INET;
+	const char *target_interface = "eth0";
+
+	char buff[INET_ADDRSTRLEN];
+	buff[0] = 0;
+
+	struct ifaddrs *ifap;
+	getifaddrs(&ifap);
+
+	for(struct ifaddrs *curr = ifap; curr != NULL; curr = curr->ifa_next) {
+		struct sockaddr *addr = curr->ifa_addr;
+		if(addr->sa_family == target_family && strcmp(curr->ifa_name, target_interface) == 0) {
+			struct sockaddr_in *addr_in = (struct sockaddr_in *)curr->ifa_addr;
+			inet_ntop(target_family, &(addr_in->sin_addr), buff, INET_ADDRSTRLEN);
+			break;
+		}
+	}
+
+	if(buff[0] == 0)
+		return 1;
+
+	rendered = text_render(buff);
+	if(rendered == NULL)
+		return 1;
+
+	return 0;
+}
+
+void reset() {
+}
+
+int draw(int argc, char **argv) {
+	for (int y = 0; y < matrix_gety(); y++) {
+		for (int x = 0; x < matrix_getx(); x++) {
+			int v = text_point(rendered, x, y) ? 255 : 0;
+			RGB color = RGB(v, v, v);
+			matrix_set(x, y, &color);
+		}
+	}
+
+	matrix_render();
+	return 0;
+}
+
+int deinit() {
+	// This acts conditionally on rendered being non-NULL.
+	text_free(rendered);
+	return 0;
+}

--- a/src/modules/gfx_ip.c
+++ b/src/modules/gfx_ip.c
@@ -79,6 +79,13 @@ void reset() {
 }
 
 int draw(int argc, char **argv) {
+	RGB black = RGB(0, 0, 0);
+	for(int y = 0; y < matrix_gety(); y++) {
+		for(int x = 0; x < matrix_getx(); x++) {
+			matrix_set(x, y, &black);
+		}
+	}
+
 	for(int i = 0; i < linecount; i++) {
 		if(lines[i] == NULL)
 			continue;
@@ -86,8 +93,8 @@ int draw(int argc, char **argv) {
 		for (int y = 0; y < matrix_gety() && y < 8; y++) {
 			for (int x = 0; x < matrix_getx(); x++) {
 				int v = text_point(lines[i], x, y) ? 255 : 0;
-				RGB color = RGB(v, v, v);
-				matrix_set(x, i * 8 + y, &color);
+				RGB colour = RGB(v, v, v);
+				matrix_set(x, i * 8 + y, &colour);
 			}
 		}
 	}


### PR DESCRIPTION
I tested the ip address retrieval and stringify code but don't have an led matrix to test the rendering.

There is a TODO for allowing to configure the network interface and ip version. Can we use `argstr` for this? Where is it set? Why does draw get `argc` and `argv` but `init` doesn't?