### PR TITLE
CI: fix remaining CI related build issues (for now, probably)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ script:
   - cp Makefiles/sledconf.ci ./sledconf
   - make -j
   - ./sled
+env:
+  - ASAN_OPTIONS="detect_odr_violation=1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os:
   - linux
   - osx
+osx_image: xcode9.2
 language: c
 compiler: clang
 script:


### PR DESCRIPTION
fixed:

- AppleClang not knowing about a new option (XCode 8 is old, XCode 9 isn't)

- odr_violation on linux - too strict, won't fix - so they're semi suppressed now (see [here](https://github.com/google/sanitizers/wiki/AddressSanitizerFlags#run-time-flags) under 'detect_odr_violation' for information)